### PR TITLE
lock down monochrome-bot dep to v2.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "Unlicense",
   "dependencies": {
-    "monochrome-bot": "^2.0.5",
+    "monochrome-bot": "2.0.5",
     "require-reload": "^0.2.2"
   }
 }


### PR DESCRIPTION
Fixes this error when `persistenceDirectoryPath` is not provided in monochrome options.
```
(node:23871) UnhandledPromiseRejectionWarning: TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be one of type string, Buffer, or URL. Received type undefined
```